### PR TITLE
Use swale as subdomain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-data.biomearts.net
+swale.biomearts.net


### PR DESCRIPTION
Let’s use `swale.biomearts.net` instead of `data.biomearts.net`